### PR TITLE
Update docker-publish.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -73,9 +73,9 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        uses: docker/build-push-action@v5.0.0
         with:
-          context: .
+          context: ./docker
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary by Sourcery

Use the official v5.0.0 tag for the Docker build-push action and switch the build context directory to ./docker in the CI workflow

CI:
- Upgrade docker/build-push-action reference to v5.0.0
- Change build context from project root to the docker subfolder