### PR TITLE
Update IERC2612.sol

### DIFF
--- a/src/Interfaces/IERC2612.sol
+++ b/src/Interfaces/IERC2612.sol
@@ -6,6 +6,4 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./IERC2612Standalone.sol";
 
 // solhint-disable-next-line no-empty-blocks
-interface IERC2612 is IERC2612Standalone, IERC20 {
-
-}
+interface IERC2612 is IERC2612Standalone, IERC20 {}


### PR DESCRIPTION
## Summary by Sourcery

Clean up the IERC2612 interface declaration by removing its redundant empty block and consolidating the declaration into a single line.

Enhancements:
- Remove unnecessary blank lines and empty interface block in IERC2612.sol
- Consolidate the IERC2612 interface declaration into a single-line definition