### PR TITLE
Update IERC2612Standalone.sol

### DIFF
--- a/src/Interfaces/IERC2612Standalone.sol
+++ b/src/Interfaces/IERC2612Standalone.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-1.0
 
 pragma solidity 0.8.17;
-
 interface IERC2612Standalone {
 	function permit(
 		address owner,
@@ -12,8 +11,5 @@ interface IERC2612Standalone {
 		bytes32 r,
 		bytes32 s
 	) external;
-
 	function nonces(address owner) external view returns (uint256);
-
-	function DOMAIN_SEPARATOR() external view returns (bytes32);
-}
+	function DOMAIN_SEPARATOR() external view returns (bytes32);{}


### PR DESCRIPTION
## Summary by Sourcery

Clean up the IERC2612Standalone interface by removing redundant blank lines and adjusting the DOMAIN_SEPARATOR declaration to include its closing braces inline.

Enhancements:
- Remove unnecessary blank lines in IERC2612Standalone.sol
- Inline the interface closing brace by appending an empty body to the DOMAIN_SEPARATOR function declaration