### PR TITLE
Create regression-tests.yml

### DIFF
--- a/.github/config /regression-tests.yml
+++ b/.github/config /regression-tests.yml
@@ -1,0 +1,806 @@
+repositories:
+  Elytro-eth/soul-wallet-contract:
+    forge-version: v0.3.0
+    hardhat-config: |
+      export default {
+        "paths": {
+          "sources": "contracts",
+          "tests": {
+            "solidity": "test"
+          }
+        },
+        "solidity": {
+          "version": "0.8.24",
+          "remappings": [
+            "@soulwallet-core/=lib/soulwallet-core/",
+            "@source/=contracts/",
+            "@arbitrum/nitro-contracts=lib/nitro-contracts/",
+            "@solady=lib/solady/",
+            "@solenv=lib/solenv/src/",
+            "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",
+            "@account-abstraction/=lib/account-abstraction/",
+            "@crypto-lib/=lib/crypto-lib/src/",
+            "forge-std/=lib/forge-std/src/",
+            "@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/"
+          ],
+          "settings": {
+            "viaIR": true,
+            "optimizer": {
+              "enabled": true,
+              "runs": 100000
+            },
+            "evmVersion": "cancun",
+            "metadata": {
+              "bytecodeHash": "none",
+              "appendCBOR": false
+            }
+          }
+        },
+        "solidityTest": {
+          "testFail": true,
+          "rpcEndpoints": {
+            "goerli": "${GOERLI_RPC_URL}",
+            "arbitrumgoerli": "${ARBITRUM_GOERLI_RPC_URL}",
+            "optimismgoerli": "${OPTIMISM_GOERLI_RPC_URL}",
+            "etherum": "${ETHERUM_RPC_URL}",
+            "arbitrum": "${ARBITRUM_RPC_URL}",
+            "optimism": "${OPTIMISM_RPC_URL}",
+            "scrollsepolia": "${SCROLL_SEPOLIA_RPC_URL}",
+            "basesepolia": "${BASE_SEPOLIA_RPC_URL}"
+          }
+        }
+      };
+    ignore: |
+      # unknown cheatcode with selector 0xce817d47 (startBroadcast(uint256))
+      test/hooks/2fa/Crypto2FAHook.t.sol
+      test/automation/ClaimInterest.t.sol
+      test/modules/socialRecovery/SocialRecoveryModule.t.sol
+
+      # unknown cheatcode with selector 0xf0259e92 (breakpoint(string))
+      test/paymaster/ERC20Paymaster.t.sol
+    ref: fc7cc084563ad1bda870df841b77caa9ee3a3661
+  PaulRBerg/prb-math:
+    forge-version: v0.3.0
+    hardhat-config: |
+      export default {
+        "paths": {
+          "sources": "src",
+          "tests": {
+            "solidity": "test"
+          }
+        },
+        "solidity": {
+          "version": "0.8.26",
+          "settings": {
+            "optimizer": {
+              "enabled": true,
+              "runs": 1000000
+            },
+            "evmVersion": "shanghai"
+          }
+        },
+        "solidityTest": {
+          "fuzz": {
+            "runs": 256
+          }
+        }
+      };
+    ref: 93be53541f39a0c1e80818a9183b2acb3908ae74
+  PaulRBerg/prb-proxy:
+    forge-version: v0.3.0
+    hardhat-config: |
+      export default {
+        "paths": {
+          "sources": "src",
+          "tests": {
+            "solidity": "test"
+          }
+        },
+        "solidity": {
+          "version": "0.8.23",
+          "settings": {
+            "optimizer": {
+              "enabled": true,
+              "runs": 200
+            },
+            "evmVersion": "paris",
+            "metadata": {
+              "bytecodeHash": "none",
+              "appendCBOR": false
+            }
+          }
+        },
+        "solidityTest": {
+          "fuzz": {
+            "runs": 1000,
+            "maxTestRejects": 1000000
+          },
+          "fsPermissions": {
+            "read": [
+              "./out-optimized"
+            ]
+          },
+          "rpcEndpoints": {
+            "arbitrum": "https://arbitrum-mainnet.infura.io/v3/${API_KEY_INFURA}",
+            "avalanche": "https://avalanche-mainnet.infura.io/v3/${API_KEY_INFURA}",
+            "bnb_smart_chain": "https://bsc-dataseed.binance.org",
+            "gnosis_chain": "https://rpc.gnosischain.com",
+            "goerli": "https://goerli.infura.io/v3/${API_KEY_INFURA}",
+            "localhost": "http://localhost:8545",
+            "mainnet": "https://eth-mainnet.g.alchemy.com/v2/${API_KEY_ALCHEMY}",
+            "optimism": "https://optimism-mainnet.infura.io/v3/${API_KEY_INFURA}",
+            "polygon": "https://polygon-mainnet.infura.io/v3/${API_KEY_INFURA}",
+            "sepolia": "https://sepolia.infura.io/v3/${API_KEY_INFURA}"
+          }
+        }
+      };
+    ref: e45f5325d4b6003227a6c4bdaefac9453f89de2e
+  PaulRBerg/prb-test:
+    forge-version: v0.3.0
+    hardhat-config: |
+      export default {
+        "paths": {
+          "sources": "src",
+          "tests": {
+            "solidity": "test"
+          }
+        },
+        "solidity": {
+          "version": "0.8.26",
+          "settings": {
+            "optimizer": {
+              "enabled": false
+            },
+            "evmVersion": "shanghai"
+          }
+        },
+        "solidityTest": {
+          "fuzz": {
+            "runs": 100,
+            "maxTestRejects": 100000
+          }
+        }
+      };
+    ref: cd07166bdd12c7c4a899cb53951653b53939a644
+  ProjectOpenSea/seaport:
+    forge-version: v0.3.0
+    hardhat-config: |
+      export default {
+        "paths": {
+          "sources": "contracts",
+          "tests": {
+            "solidity": "test/foundry"
+          }
+        },
+        "solidity": {
+          "version": "0.8.24",
+          "remappings": [
+            "@rari-capital/solmate/=lib/solmate/",
+            "ds-test/=lib/ds-test/src/",
+            "forge-std/=lib/forge-std/src/",
+            "murky/=lib/murky/src/",
+            "@openzeppelin/=lib/openzeppelin-contracts/",
+            "solarray/=lib/solarray/src/",
+            "solady/=lib/solady/",
+            "seaport-sol/=lib/seaport-sol/",
+            "seaport-types/=lib/seaport-types/",
+            "seaport-core/=lib/seaport-core/",
+            "seaport/=contracts/"
+          ],
+          "settings": {
+            "evmVersion": "cancun",
+            "optimizer": {
+              "runs": 4294967292
+            }
+          }
+        },
+        "solidityTest": {
+          "fuzz": {
+            "runs": 1000
+          },
+          "fsPermissions": {
+            "read": [
+              "./optimized-out",
+              "./reference-out"
+            ],
+            "write": [
+              "./call-metrics.txt",
+              "./mutation-metrics.txt",
+              "./assume-metrics.txt",
+              "./fuzz_debug.json"
+            ]
+          }
+        }
+      };
+    ignore: |
+      # Invalid hex bytecode for contract (this is caused by the lack of support for dynamic linking)
+      test/foundry
+    ref: 585b2ef8376dd979171522027bbdb048c2a4999c
+  Uniswap/UniswapX:
+    forge-version: v0.3.0
+    hardhat-config: |
+      export default {
+        "paths": {
+          "sources": "src",
+          "tests": {
+            "solidity": "test"
+          }
+        },
+        "solidity": {
+          "version": "0.8.24",
+          "remappings": [
+            "ds-test/=lib/forge-std/lib/ds-test/src/",
+            "forge-gas-snapshot/=lib/forge-gas-snapshot/src/",
+            "forge-std/=lib/forge-std/src/",
+            "openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/",
+            "permit2/=lib/permit2/",
+            "solmate/=lib/solmate/",
+            "solarray/=lib/solarray/src/"
+          ],
+          "settings": {
+            "optimizer": {
+              "runs": 1000000
+            }
+          }
+        },
+        "solidityTest": {
+          "ffi": true,
+          "fsPermissions": {
+            "readWrite": [
+              ".forge-snapshots/"
+            ]
+          }
+        }
+      };
+    ignore: |
+      */integration/*
+
+      # unknown cheatcode with selector 0x7fb5297f (startBroadcast())
+      test/script/DeployDutch.t.sol
+      test/script/DeployExclusiveDutch.t.sol
+      test/script/DeployPriorityOrderReactor.t.sol
+
+      # unknown cheatcode with selector 0x3cad9d7b (startSnapshotGas(string))
+      test/base/EthOutput.t.sol
+      test/validation-contracts/ExclusiveFillerValidation.t.sol
+      test/lib/NonLinearDutchDecayLib.t.sol
+      test/base/ProtocolFees.t.sol
+      test/fill-macros/DirectTakerFillMacro.t.sol
+      test/executors/SwapRouter02Executor.t.sol
+
+      # unknown cheatcode with selector 0xdd9fca12 (snapshotGasLastCall(string))
+      test/base/BaseReactor.t.sol
+      test/reactors/PriorityOrderReactor.t.sol
+      test/reactors/V3DutchOrderReactor.t.sol
+      test/reactors/V2DutchOrderReactor.t.sol
+      test/reactors/LimitOrderReactor.t.sol
+      test/reactors/BaseDutchOrderReactor.t.sol
+      test/reactors/ExclusiveDutchOrderReactor.t.sol
+      test/reactors/DutchOrderReactor.t.sol
+    ref: 4013dfa4bc53b823b406b035a9b5eb579607eb99
+  Vectorized/solady:
+    forge-version: v0.3.0
+    hardhat-config: |
+      export default {
+        "paths": {
+          "sources": "src",
+          "tests": {
+            "solidity": "test"
+          }
+        },
+        "solidity": {
+          "version": "0.8.28",
+          "remappings": [
+            "forge-std=test/utils/forge-std/"
+          ],
+          "settings": {
+            "optimizer": {
+              "enabled": true,
+              "runs": 1000
+            },
+            "evmVersion": "cancun"
+          }
+        },
+        "solidityTest": {
+          "blockGasLimit": BigInt(100000000),
+          "fsPermissions": {
+            "read": [
+              "./test/data"
+            ]
+          },
+          "fuzz": {
+            "runs": 256
+          },
+          "invariant": {
+            "depth": 15,
+            "runs": 10
+          }
+        }
+      };
+    ignore: |
+      */*7702*
+      */*Transient*
+      */ext/ithaca/*
+      */ext/zksync/*
+
+      # testP256Normalized(uint256,bytes32): unknown cheatcode with selector 0xc453949e (publicKeyP256(uint256))
+      test/P256.t.sol
+      test/WebAuthn.t.sol
+
+      # https://github.com/NomicFoundation/hardhat/issues/6509
+      # testBumpSlot(bytes32,uint256): Unknown error
+      test/LibStorage.t.sol
+
+      # https://github.com/NomicFoundation/hardhat/issues/6509
+      # testTargetGenerate(): Transaction reverted: contract call run out of gas and made the transaction revert
+      test/DeploylessPredeployQueryer.t.sol
+    ref: c9e079c0ca836dcc52777a1fa7227ef28e3537b3
+  foundry-rs/forge-std:
+    forge-version: v0.3.0
+    hardhat-config: |
+      export default {
+        "paths": {
+          "sources": "src",
+          "tests": {
+            "solidity": "test"
+          }
+        },
+        "solidity": {
+          "version": "0.8.26",
+          "settings": {
+            "optimizer": {
+              "enabled": true,
+              "runs": 200
+            }
+          }
+        },
+        "solidityTest": {
+          "fsPermissions": {
+            "readWrite": [
+              "./"
+            ]
+          },
+          "rpcEndpoints": {
+            "mainnet": "https://eth-mainnet.alchemyapi.io/v2/WV407BEiBmjNJfKo9Uo_55u0z0ITyCOX",
+            "optimism_sepolia": "https://sepolia.optimism.io/",
+            "arbitrum_one_sepolia": "https://sepolia-rollup.arbitrum.io/rpc/",
+            "needs_undefined_env_var": "${UNDEFINED_RPC_URL_PLACEHOLDER}"
+          }
+        }
+      };
+    ignore: |
+      # test_DeriveRememberKey(): unknown cheatcode with selector 0x6229498b (deriveKey(string,uint32))
+      test/StdCheats.t.sol
+
+      # StdUtilsForkTest.setUp(): Could not instantiate forked environment. Fork host: 'eth-mainnet.alchemyapi.io' (this is caused by using an invalid mainnet rpc endpoint)
+      test/StdUtils.t.sol
+
+      # test_RevertIf_ChainBubbleUp(): call did not revert as expected (this is caused by using an invalid mainnet rpc endpoint)
+      # test_ChainRpcInitialization(): assertion failed: https://eth-mainnet.alchemyapi.io/v2/WV407BEiBmjNJfKo9Uo_55u0z0ITyCOX != https://eth.merkle.io
+      test/StdChains.t.sol
+    ref: 8ba9031ffcbe25aa0d1224d3ca263a995026e477
+  kalidao/keep:
+    forge-version: v0.3.0
+    hardhat-config: |
+      export default {
+        "paths": {
+          "sources": "contracts",
+          "tests": {
+            "solidity": "test"
+          }
+        },
+        "solidity": {
+          "version": "0.8.18",
+          "remappings": [
+            "@std/=lib/forge-std/src/",
+            "@solady/=lib/solady/",
+            "ds-test/=lib/forge-std/lib/ds-test/src/",
+            "forge-std/=lib/forge-std/src/"
+          ],
+          "settings": {
+            "optimizer": {
+              "runs": 9999999
+            }
+          }
+        },
+        "solidityTest": {
+          "testFail": true
+        }
+      };
+    ref: 21213d34042b8a5a68afeb590f43018f08c81a58
+  mds1/multicall:
+    forge-version: v0.3.0
+    hardhat-config: |
+      export default {
+        "paths": {
+          "sources": "src",
+          "tests": {
+            "solidity": "src/test"
+          }
+        },
+        "solidity": {
+          "version": "0.8.12",
+          "settings": {
+            "optimizer": {
+              "enabled": true,
+              "runs": 10000000
+            }
+          },
+          "remappings": [
+            "forge-std/=lib/forge-std/src/",
+            "ds-test/=lib/forge-std/lib/ds-test/src/"
+          ]
+        },
+        "solidityTest": {
+          "fuzz": {
+            "runs": 1000
+          }
+        }
+      };
+    ref: 19da7a56668b7b284901ef0551edb23905c6cd53
+  pancakeswap/infinity-core:
+    forge-version: v0.3.0
+    hardhat-config: |
+      export default {
+        "paths": {
+          "sources": "src",
+          "tests": {
+            "solidity": "test"
+          }
+        },
+        "solidity": {
+          "version": "0.8.26",
+          "remappings": [
+            "ds-test/=lib/forge-std/lib/ds-test/src/",
+            "forge-std/=lib/forge-std/src/",
+            "@openzeppelin/=lib/openzeppelin-contracts/",
+            "solmate/=lib/solmate/",
+            "forge-gas-snapshot/=lib/forge-gas-snapshot/src/"
+          ],
+          "settings": {
+            "viaIR": true,
+            "optimizer": {
+              "runs": 25666
+            },
+            "evmVersion": "cancun",
+            "metadata": {
+              "bytecodeHash": "none"
+            }
+          }
+        },
+        "solidityTest": {
+          "testFail": true,
+          "ffi": true,
+          "fsPermissions": {
+            "readWrite": [
+              ".forge-snapshots/"
+            ],
+            "read": [
+              "./foundry-out",
+              "./script/config",
+              "./test/pool-cl/bin",
+              "./test/pool-bin/bin"
+            ]
+          },
+          "blockGasLimit": BigInt(300000000),
+          "fuzz": {
+            "runs": 5
+          }
+        }
+      };
+    ignore: |
+      # https://github.com/NomicFoundation/hardhat/issues/6509
+      # TokenLocker.setUp(): Transaction reverted without a reason string
+      test/vault/VaultReentrancy.t.sol
+
+      # https://github.com/NomicFoundation/hardhat/issues/6509
+      # The test is not safe to replay because it uses impure cheatcodes: function ffi(string[] calldata commandInput) external returns (bytes memory result);
+      # TickMathTestTest.test_getTickAtSqrtRatio_matchesJavascriptImplWithin1(): EvmError: Revert
+      # TickMathTestTest.test_getSqrtRatioAtTick_matchesJavaScriptImplByOneHundrethOfABip(): EvmError: Revert
+      test/pool-cl/libraries/TickMath.t.sol
+
+      # unknown cheatcode with selector 0x3cad9d7b (startSnapshotGas(string))
+      test/pool-cl/libraries/BitMath.t.sol
+      test/pool-cl/libraries/CLPosition.t.sol
+      test/pool-cl/libraries/LiquidityMath.t.sol
+      test/pool-cl/libraries/SqrtPriceMath.t.sol
+      test/pool-cl/libraries/SwapMath.t.sol
+      test/pool-cl/libraries/Tick.t.sol
+
+      # unknown cheatcode with selector 0x51db805a (snapshotValue(string,uint256))
+      test/pool-bin/BinPoolManager.t.sol
+      test/pool-cl/CLPoolManager.t.sol
+      test/vault/Vault.t.sol
+
+      # unknown cheatcode with selector 0xdd9fca12 (snapshotGasLastCall(string))
+      test/Extsload.t.sol
+      test/pool-bin/BinCustomCurveHook.t.sol
+      test/pool-bin/BinHook.t.sol
+      test/pool-bin/BinMintBurnFeeHook.t.sol
+      test/pool-bin/BinPoolManager.t.sol
+      test/pool-bin/libraries/BinPoolSwap.t.sol
+      test/pool-cl/CLCustomCurveHook.t.sol
+      test/pool-cl/CLMintBurnFeeHook.t.sol
+      test/pool-cl/libraries/TickBitmap.t.sol
+    ref: 9a050c44cdf801fd19753409e6a03a8026a1fd09
+  pcaversaccio/createx:
+    forge-version: v0.3.0
+    hardhat-config: |
+      export default {
+        "paths": {
+          "sources": "src",
+          "tests": {
+            "solidity": "test"
+          }
+        },
+        "solidity": {
+          "version": "0.8.23",
+          "remappings": [
+            "solady/=lib/solady/src/",
+            "forge-std/=lib/forge-std/src/",
+            "openzeppelin/=lib/openzeppelin-contracts/contracts/"
+          ],
+          "settings": {
+            "optimizer": {
+              "enabled": true,
+              "runs": 10000000
+            },
+            "viaIR": false,
+            "evmVersion": "paris",
+            "metadata": {
+              "bytecodeHash": "none"
+            }
+          }
+        },
+        "solidityTest": {
+          "fuzz": {
+            "runs": 100
+          },
+          "fsPermissions": {
+            "readWrite": [
+              "./"
+            ]
+          },
+          "invariant": {
+            "runs": 256,
+            "depth": 15
+          }
+        }
+      };
+    ignore: |
+      # unknown cheatcode with selector 0x9cd23835 (snapshotState())
+      test/public/CREATE2/CreateX.deployCreate2AndInit_4Args_CustomiseSalt.t.sol
+      test/public/CREATE2/CreateX.deployCreate2AndInit_4Args_CustomiseSalt.t.sol
+      test/public/CREATE2/CreateX.deployCreate2AndInit_5Args.t.sol
+      test/public/CREATE2/CreateX.deployCreate2AndInit_5Args.t.sol
+      test/public/CREATE2/CreateX.deployCreate2Clone_3Args.t.sol
+      test/public/CREATE3/CreateX.deployCreate3AndInit_4Args_CustomiseRefundAddress.t.sol
+      test/public/CREATE3/CreateX.deployCreate3AndInit_4Args_CustomiseRefundAddress.t.sol
+      test/public/CREATE2/CreateX.deployCreate2_2Args.t.sol
+      test/public/CREATE3/CreateX.deployCreate3AndInit_3Args.t.sol
+      test/public/CREATE3/CreateX.deployCreate3AndInit_3Args.t.sol
+      test/public/CREATE3/CreateX.deployCreate3_2Args.t.sol
+      test/public/CREATE3/CreateX.deployCreate3AndInit_5Args.t.sol
+      test/public/CREATE3/CreateX.deployCreate3AndInit_5Args.t.sol
+      test/public/CREATE3/CreateX.deployCreate3_1Arg.t.sol
+      test/public/CREATE3/CreateX.deployCreate3AndInit_4Args_CustomiseSalt.t.sol
+      test/public/CREATE3/CreateX.deployCreate3AndInit_4Args_CustomiseSalt.t.sol
+      test/internal/CreateX._generateSalt.t.sol
+    ref: ac7e49b93030145a646c6cffd62a81f447422309
+  sablier-labs/lockup:
+    env: |
+      RPC_URL_MAINNET="https://eth-mainnet.g.alchemy.com/v2/<api-key>"
+    forge-version: v0.3.0
+    hardhat-config: |
+      export default {
+        "paths": {
+          "sources": "src",
+          "tests": {
+            "solidity": "tests"
+          }
+        },
+        "solidity": {
+          "version": "0.8.26",
+          "remappings": [
+            "@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/",
+            "@prb/math/=node_modules/@prb/math/",
+            "forge-std/=node_modules/forge-std/",
+            "solady/=node_modules/solady/",
+            "solarray/=node_modules/solarray/"
+          ],
+          "settings": {
+            "optimizer": {
+              "enabled": true,
+              "runs": 570
+            },
+            "evmVersion": "shanghai",
+            "metadata": {
+              "bytecodeHash": "none"
+            }
+          }
+        },
+        "solidityTest": {
+          "fsPermissions": {
+            "read": [
+              "./out-optimized",
+              "package.json"
+            ],
+            "readWrite": [
+              "./benchmark/results",
+              "./script/"
+            ]
+          },
+          "blockGasLimit": BigInt(9223372036854775807),
+          "fuzz": {
+            "runs": 50,
+            "maxTestRejects": 1000000
+          },
+          "invariant": {
+            "runs": 20,
+            "depth": 20,
+            "failOnRevert": true,
+            "callOverride": false
+          },
+          "sender": "0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38",
+          "rpcEndpoints": {
+            "arbitrum": "${ARBITRUM_RPC_URL}",
+            "arbitrum_sepolia": "https://arbitrum-sepolia-rpc.publicnode.com",
+            "avalanche": "${AVALANCHE_RPC_URL}",
+            "base": "https://mainnet.base.org",
+            "base_sepolia": "https://sepolia.base.org",
+            "berachain_artio": "https://bartio.rpc.berachain.com/",
+            "blast": "https://rpc.blast.io",
+            "blast_sepolia": "https://sepolia.blast.io",
+            "bnb": "https://bsc-dataseed.binance.org",
+            "core_dao": "https://rpc.coredao.org",
+            "gnosis": "https://rpc.gnosischain.com",
+            "lightlink": "https://replicator.phoenix.lightlink.io/rpc/v1",
+            "linea": "https://rpc.linea.build",
+            "linea_sepolia": "https://rpc.sepolia.linea.build",
+            "localhost": "http://localhost:8545",
+            "mainnet": "${MAINNET_RPC_URL}",
+            "mode": "https://mainnet.mode.network/",
+            "mode_sepolia": "https://sepolia.mode.network/",
+            "morph": "https://rpc.morphl2.io",
+            "optimism": "${OPTIMISM_RPC_URL}",
+            "optimism_sepolia": "https://sepolia.optimism.io",
+            "polygon": "${POLYGON_RPC_URL}",
+            "scroll": "https://rpc.scroll.io/",
+            "sei": "https://evm-rpc.sei-apis.com",
+            "sei_testnet": "https://evm-rpc.arctic-1.seinetwork.io",
+            "sepolia": "${SEPOLIA_RPC_URL}",
+            "superseed": "https://mainnet.superseed.xyz",
+            "superseed_sepolia": "https://sepolia.superseed.xyz",
+            "taiko_hekla": "https://rpc.hekla.taiko.xyz",
+            "taiko_mainnet": "https://rpc.mainnet.taiko.xyz"
+          }
+        }
+      };
+    ignore: |
+      # Invalid hex bytecode for contract (this is caused by the lack of support for dynamic linking)
+      tests
+    ref: a8528a6d0ca25f4f36eb9327fc87e08dc78ad0a6
+  sablier-labs/v2-periphery:
+    env: |
+      RPC_URL_MAINNET="https://eth-mainnet.g.alchemy.com/v2/<api-key>"
+    forge-version: v0.3.0
+    hardhat-config: |
+      export default {
+        "paths": {
+          "sources": "src",
+          "tests": {
+            "solidity": "test"
+          }
+        },
+        "solidity": {
+          "version": "0.8.26",
+          "remappings": [
+            "@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/",
+            "@prb/math/=node_modules/@prb/math/",
+            "@sablier/v2-core/=node_modules/@sablier/v2-core/",
+            "forge-std/=node_modules/forge-std/",
+            "solady/=node_modules/solady/"
+          ],
+          "settings": {
+            "optimizer": {
+              "enabled": true,
+              "runs": 10000
+            },
+            "evmVersion": "shanghai",
+            "metadata": {
+              "bytecodeHash": "none"
+            }
+          }
+        },
+        "solidityTest": {
+          "blockTimestamp": BigInt(1714518000),
+          "fsPermissions": {
+            "read": [
+              "./out-optimized",
+              "package.json"
+            ],
+            "readWrite": [
+              "./benchmark/results",
+              "./cache"
+            ]
+          },
+          "blockGasLimit": BigInt(9223372036854775807),
+          "sender": "0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38",
+          "fuzz": {
+            "runs": 20,
+            "maxTestRejects": 1000000
+          },
+          "rpcEndpoints": {
+            "arbitrum": "${ARBITRUM_RPC_URL}",
+            "arbitrum_sepolia": "https://arbitrum-sepolia.blockpi.network/v1/rpc/public",
+            "avalanche": "${AVALANCHE_RPC_URL}",
+            "base": "https://mainnet.base.org",
+            "base_sepolia": "https://sepolia.base.org",
+            "bnb": "https://bsc-dataseed.binance.org",
+            "gnosis": "https://rpc.gnosischain.com",
+            "localhost": "http://localhost:8545",
+            "mainnet": "${MAINNET_RPC_URL}",
+            "optimism": "${OPTIMISM_RPC_URL}",
+            "optimism_sepolia": "https://sepolia.optimism.io",
+            "polygon": "${POLYGON_RPC_URL}",
+            "scroll": "https://rpc.scroll.io/",
+            "sepolia": "${SEPOLIA_RPC_URL}"
+          }
+        }
+      };
+    ignore: |
+      # unknown cheatcode with selector 0x6229498b (deriveKey(string,uint32))
+      test/utils/BaseScript.t.sol
+
+      # Could not instantiate forked environment. Received invalid url. (this is caused by using an invalid url for one of the rpc endpoints)
+      test/fork/assets/USDC.t.sol
+      test/fork/assets/USDT.t.sol
+    ref: c3ea8d7f7aab4cb33c6b4517ba38d32ca35b1257
+  transmissions11/solmate:
+    forge-version: v0.3.0
+    hardhat-config: |
+      export default {
+        "paths": {
+          "sources": "src",
+          "tests": {
+            "solidity": "src/test"
+          }
+        },
+        "solidity": {
+          "version": "0.8.15",
+          "remappings": [
+            "ds-test/=lib/ds-test/src/"
+          ],
+          "settings": {
+            "optimizer": {
+              "runs": 1000000
+            },
+            "metadata": {
+              "bytecodeHash": "none"
+            }
+          }
+        },
+        "solidityTest": {
+          "testFail": true
+        }
+      };
+    ref: c93f7716c9909175d45f6ef80a34a650e2d24e56
+
+runners:
+  ubuntu-latest: {}
+  windows-latest: {}
+  macos-latest: {}
+
+commands:
+  forge build:
+    pattern: 'Compiling (\d+) files with Solc \d+\.\d+'
+    template: "Compiled ${0} file(s)"
+  forge test:
+    pattern: 'Ran \d+ test suites in \d+\.\d+m?s \(\d+\.\d+m?s CPU time\): (\d+) tests passed, (\d+) failed, (\d+) skipped \((\d+) total tests\)'
+    template: "Ran ${3} tests (${0} passed, ${1} failed, ${2} skipped)"
+  hardhat compile:
+    pattern: 'Compiled (\d+) Solidity files with solc \d+\.\d+'
+    template: "Compiled ${0} file(s)"
+  hardhat test solidity:
+    pattern: 'Run (?:Failed|Passed): (\d+) tests, (\d+) passed, (\d+) failed, (\d+) skipped \(duration: \d+ ms\)'
+    template: "Ran ${0} tests (${1} passed, ${2} failed, ${3} skipped)"


### PR DESCRIPTION
## Summary by Sourcery

Add a new regression-tests.yml to centralize regression testing configuration for multiple Solidity repositories and standardize CI runners and command output parsing

New Features:
- Centralize per-repo regression test settings including forge versions, Hardhat configurations, ignore patterns, and specific Git refs
- Define CI runners for ubuntu-latest, windows-latest, and macos-latest environments
- Introduce command output templates for forge build/test and Hardhat compile/test