### PR TITLE
Fix formatting and add DOMAIN_SEPARATOR function

### DIFF
--- a/src/Interfaces/IERC2612Standalone.sol
+++ b/src/Interfaces/IERC2612Standalone.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-1.0
 
 pragma solidity 0.8.17;
-
 interface IERC2612Standalone {
 	function permit(
 		address owner,
@@ -12,8 +11,5 @@ interface IERC2612Standalone {
 		bytes32 r,
 		bytes32 s
 	) external;
-
 	function nonces(address owner) external view returns (uint256);
-
-	function DOMAIN_SEPARATOR() external view returns (bytes32);
-}
+	function DOMAIN_SEPARATOR() external view returns (bytes32);{}


### PR DESCRIPTION
## Summary by Sourcery

Clean up formatting in IERC2612Standalone interface and convert the DOMAIN_SEPARATOR declaration into a stub with an empty body

Enhancements:
- Remove unnecessary blank lines and adjust indentation in IERC2612Standalone.sol
- Add an empty function body to the DOMAIN_SEPARATOR declaration