### PR TITLE
Revert "Install Vercel Web Analytics for Next.js"

### DIFF
--- a/packages/create-wagmi/templates/next/package.json
+++ b/packages/create-wagmi/templates/next/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@tanstack/react-query": "latest",
-    "@vercel/analytics": "latest",
     "next": "latest",
     "react": "latest",
     "react-dom": "latest",

--- a/packages/create-wagmi/templates/next/src/app/layout.tsx
+++ b/packages/create-wagmi/templates/next/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import './globals.css'
-import { Analytics } from '@vercel/analytics/next'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import { headers } from 'next/headers'
@@ -25,7 +24,6 @@ export default async function RootLayout(props: { children: ReactNode }) {
     <html lang="en">
       <body className={inter.className}>
         <Providers initialState={initialState}>{props.children}</Providers>
-        <Analytics />
       </body>
     </html>
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -377,6 +377,8 @@ importers:
         specifier: 'catalog:'
         version: 19.2.3
 
+  packages/register-tests/solid: {}
+
   packages/register-tests/vue:
     dependencies:
       '@tanstack/vue-query':
@@ -460,10 +462,10 @@ importers:
         version: 5.49.2(react@19.2.0)
       '@vercel/analytics':
         specifier: ^1.6.1
-        version: 1.6.1(next@16.0.10(@babel/core@7.28.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(vue-router@4.6.3(vue@3.5.25(typescript@5.9.3)))(vue@3.5.25(typescript@5.9.3))
+        version: 1.6.1(next@16.0.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(vue-router@4.6.3(vue@3.5.25(typescript@5.9.3)))(vue@3.5.25(typescript@5.9.3))
       next:
         specifier: ^16.0.7
-        version: 16.0.10(@babel/core@7.28.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.0.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react:
         specifier: 'catalog:'
         version: 19.2.0
@@ -657,6 +659,8 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 7.2.2(@types/node@24.6.2)(jiti@2.6.1)(terser@5.31.0)(tsx@4.20.6)(yaml@2.8.1)
+
+  playgrounds/vite-solid: {}
 
   playgrounds/vite-vue:
     dependencies:
@@ -15150,9 +15154,9 @@ snapshots:
       unplugin-utils: 0.3.1
       vite: 7.2.2(@types/node@24.6.2)(jiti@2.6.1)(terser@5.31.0)(tsx@4.20.6)(yaml@2.8.1)
 
-  '@vercel/analytics@1.6.1(next@16.0.10(@babel/core@7.28.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(vue-router@4.6.3(vue@3.5.25(typescript@5.9.3)))(vue@3.5.25(typescript@5.9.3))':
+  '@vercel/analytics@1.6.1(next@16.0.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(vue-router@4.6.3(vue@3.5.25(typescript@5.9.3)))(vue@3.5.25(typescript@5.9.3))':
     optionalDependencies:
-      next: 16.0.10(@babel/core@7.28.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next: 16.0.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       vue: 3.5.25(typescript@5.9.3)
       vue-router: 4.6.3(vue@3.5.25(typescript@5.9.3))
@@ -18946,7 +18950,7 @@ snapshots:
 
   nanotar@0.2.0: {}
 
-  next@16.0.10(@babel/core@7.28.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  next@16.0.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@next/env': 16.0.10
       '@swc/helpers': 0.5.15
@@ -18954,7 +18958,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.0)
+      styled-jsx: 5.1.6(react@19.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.0.10
       '@next/swc-darwin-x64': 16.0.10
@@ -20974,12 +20978,10 @@ snapshots:
 
   structured-clone-es@1.0.0: {}
 
-  styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.2.0):
+  styled-jsx@5.1.6(react@19.2.0):
     dependencies:
       client-only: 0.0.1
       react: 19.2.0
-    optionalDependencies:
-      '@babel/core': 7.28.5
 
   stylehacks@7.0.6(postcss@8.5.6):
     dependencies:


### PR DESCRIPTION
Reverts Dargon789/template-ethereum-contracts#166

## Summary by Sourcery

Enhancements:
- Remove the @vercel/analytics dependency and associated Analytics component usage from the Next.js app layout.