### PR TITLE
Potential fix for code scanning alert no. 14: Insecure randomness

### DIFF
--- a/packages/core/src/utils/uid.ts
+++ b/packages/core/src/utils/uid.ts
@@ -1,14 +1,20 @@
+import { randomBytes } from 'node:crypto'
+
 const size = 256
 let index = size
 let buffer: string
 
 export function uid(length = 11) {
   if (!buffer || index + length > size * 2) {
-    buffer = ''
     index = 0
-    for (let i = 0; i < size; i++) {
-      buffer += ((256 + Math.random() * 256) | 0).toString(16).substring(1)
-    }
+    const bytes =
+      typeof globalThis.crypto !== 'undefined' &&
+      typeof globalThis.crypto.getRandomValues === 'function'
+        ? globalThis.crypto.getRandomValues(new Uint8Array(size))
+        : randomBytes(size)
+    buffer = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join(
+      '',
+    )
   }
   return buffer.substring(index, index++ + length)
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/template-ethereum-contracts/security/code-scanning/14](https://github.com/Dargon789/template-ethereum-contracts/security/code-scanning/14)

Use Node/browser cryptographic randomness for UID generation instead of `Math.random()`.

Best fix here: update `packages/core/src/utils/uid.ts` to generate random bytes via `globalThis.crypto.getRandomValues` when available, with a Node fallback using `node:crypto` `randomBytes`. Convert bytes to two-digit hex and keep the same buffered/sliced UID behavior so call sites (`uid()`, default length 11, substring logic) remain unchanged.

Changes needed:
- In `packages/core/src/utils/uid.ts`:
  - Add import for `randomBytes` from `node:crypto`.
  - Replace the loop that appends `Math.random()`-derived hex with CSPRNG-backed bytes.
  - Keep `size`, `index`, `buffer`, function signature, and return semantics intact.

No changes are required in `createConfig.ts` or `createEmitter.ts`; they will automatically consume stronger IDs via `uid()`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Eliminate use of Math.random() for UID generation in favor of cryptographically secure random bytes.